### PR TITLE
add conditional dependency for python3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,10 @@ setup(name='simplesbml',
       author='Caroline Cannistra, Kyle Medley',
       author_email='tellurium-discuss@googlegroups.com',
       url='http://simplesbml.readthedocs.io/en/latest/',
-      install_requires=['tesbml>=5.15.0'],
-      packages=['simplesbml'])
+      install_requires=[],
+      packages=['simplesbml'],
+      extras_require={
+          ':python_version=="3.7"': ['python-libsbml>=5.18.0'],
+          ':python_version<"3.7"': ['tesbml>=5.15.0']
+      }
+)


### PR DESCRIPTION
This should install python-libsbml when the python version is 3.7.x, up to python version 3.6.x tesbml will be installed as dependency.